### PR TITLE
fix: graphify workflow — create PR instead of direct push to dev-msf

### DIFF
--- a/.github/workflows/update-graphify.yml
+++ b/.github/workflows/update-graphify.yml
@@ -27,7 +27,8 @@ jobs:
     # Éviter une boucle infinie : skip les commits faits par le bot lui-même
     if: github.actor != 'github-actions[bot]'
     permissions:
-      contents: write   # nécessaire pour git push
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -88,21 +89,32 @@ jobs:
             echo "📝 GRAPH_REPORT.md changed — will commit"
           fi
 
-      - name: Commit and push updated report
+      - name: Commit and push updated report via PR
         if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          BRANCH="graphify/update-graph-report"
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Crée/réinitialise la branche dédiée depuis dev-msf
+          git checkout -B "$BRANCH"
           git add graphify-out/GRAPH_REPORT.md
           git commit --no-verify -m "chore: update graphify graph report [skip ci]"
-          if ! git pull --rebase origin dev-msf; then
-            if [ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]; then
-              git rebase --abort || true
-              echo "::warning::Rebase conflict — graph report commit skipped. Will retry on next push."
-              exit 0
-            fi
-            echo "::error::git pull --rebase failed for a non-conflict reason."
-            exit 1
+          git push -f origin "$BRANCH"
+
+          # Crée la PR si elle n'existe pas encore
+          if ! gh pr view "$BRANCH" --json number -q .number 2>/dev/null; then
+            gh pr create \
+              --base dev-msf \
+              --head "$BRANCH" \
+              --title "chore: update graphify graph report [skip ci]" \
+              --body "Mise à jour automatique du rapport de dépendances Graphify."
           fi
-          git push
-          echo "✅ Graph report updated and pushed!"
+
+          # Active l'auto-merge (squash) — se fusionne dès que les checks passent
+          gh pr merge "$BRANCH" --auto --squash 2>/dev/null || true
+
+          echo "✅ PR du rapport Graphify créée/mise à jour !"


### PR DESCRIPTION
## Summary

- Le workflow Graphify échouait avec `GH006: Protected branch update failed` parce qu'il essayait de pousser directement sur `dev-msf` (branche protégée).
- Nouveau comportement : le rapport est commité sur la branche `graphify/update-graph-report`, une PR est créée automatiquement vers `dev-msf`, et l'auto-merge (squash) est activé.

## Changements

- `.github/workflows/update-graphify.yml` : remplace le push direct + rebase par une PR via `gh pr create` + `gh pr merge --auto --squash`
- Permission `pull-requests: write` ajoutée au job

## Test plan

- [ ] Merger cette PR
- [ ] Déclencher manuellement le workflow (Actions → Update Graphify Graph → Run workflow)
- [ ] Vérifier qu'une PR `graphify/update-graph-report → dev-msf` est créée automatiquement

https://claude.ai/code/session_015dEDZHpYezVNV4GSjg2yuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015dEDZHpYezVNV4GSjg2yuZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the automated graph report update process to use pull requests for better review workflows and auto-merge capabilities instead of direct commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->