### PR TITLE
fix: remove semantic pass — graphify . not valid in v0.5.7

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *)   [ -f graphify-out/GRAPH_REPORT.md ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}'   || true ;; esac"
+            "command": "ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd); CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *)   [ -f \"$ROOT/graphify-out/GRAPH_REPORT.md\" ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}'   || true ;; esac"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,17 @@
         "type": "command",
         "command": "bash .claude/hooks/session-start.sh"
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *)   [ -f graphify-out/graph.json ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}'   || true ;; esac"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *)   [ -f graphify-out/graph.json ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}'   || true ;; esac"
+            "command": "CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *)   [ -f graphify-out/GRAPH_REPORT.md ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}'   || true ;; esac"
           }
         ]
       }

--- a/.github/workflows/update-graphify.yml
+++ b/.github/workflows/update-graphify.yml
@@ -3,11 +3,6 @@ name: Update Graphify Graph
 
 on:
   workflow_dispatch:
-    inputs:
-      semantic:
-        description: 'Run full semantic pass (uses ANTHROPIC_API_KEY — incurs API cost)'
-        type: boolean
-        default: false
   push:
     branches: [dev-msf]
     paths:
@@ -58,15 +53,8 @@ jobs:
 
       - name: Update graph
         run: |
-          if [ "${{ inputs.semantic }}" = "true" ]; then
-            echo "🧠 Running full semantic pass (graphify .)"
-            graphify .
-          else
-            echo "🔍 Running AST-only pass (graphify update .)"
-            graphify update .
-          fi
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          echo "🔍 Running AST pass (graphify update .)"
+          graphify update .
 
       - name: Regenerate Mermaid block in GRAPH_REPORT.md
         run: python3 scripts/generate-graph-mermaid.py

--- a/.github/workflows/update-graphify.yml
+++ b/.github/workflows/update-graphify.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install graphifyy
-        run: pip install graphifyy
+        run: pip install "graphifyy==0.5.7"
 
       # Cache graph.json pour éviter de recalculer les edges déjà connus
       - name: Restore graph.json cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,12 +150,10 @@ Use these four commands in sequence for any non-trivial change:
 `graphify-out/GRAPH_REPORT.md` is a dependency graph of the `RUFAS/` module, auto-committed to `dev-msf` by CI on every push. The session-start hook injects it into each Claude Code session automatically.
 
 - **AST pass** (`graphify update .`) — free, runs on every push to `dev-msf` via CI. Captures all structural dependencies (imports, calls, inheritance).
-- **Semantic pass** (`graphify .`) — uses `ANTHROPIC_API_KEY`, run manually once to enrich the graph with inferred relationships.
 
-### Triggering a semantic pass
+### Triggering a manual update
 
-GitHub → Actions → **Update Graphify Graph** → Run workflow → check **"Run full semantic pass"**.
-Requires `ANTHROPIC_API_KEY` to be set as a GitHub repository secret.
+GitHub → Actions → **Update Graphify Graph** → Run workflow. The CI creates a PR `graphify/update-graph-report → dev-msf` with the updated report.
 
 ### How Claude uses the graph
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,3 +158,13 @@ GitHub → Actions → **Update Graphify Graph** → Run workflow. The CI create
 ### How Claude uses the graph
 
 `/diagnose` reads `graphify-out/GRAPH_REPORT.md` at the start of every analysis to identify god nodes (high-degree files) in the blast radius of a change, prioritize file exploration, and anticipate ripple effects before writing the plan.
+
+## graphify
+
+This project has a graphify knowledge graph at graphify-out/.
+
+Rules:
+- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
+- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
+- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,13 +147,13 @@ Use these four commands in sequence for any non-trivial change:
 
 ## Graphify Dependency Graph
 
-`graphify-out/GRAPH_REPORT.md` is a dependency graph of the `RUFAS/` module, auto-committed to `dev-msf` by CI on every push. The session-start hook injects it into each Claude Code session automatically.
+`graphify-out/GRAPH_REPORT.md` is a dependency graph of the `RUFAS/` module, updated via PR to `dev-msf` by CI on every push to `RUFAS/`. The session-start hook injects it into each Claude Code session automatically.
 
 - **AST pass** (`graphify update .`) — free, runs on every push to `dev-msf` via CI. Captures all structural dependencies (imports, calls, inheritance).
 
 ### Triggering a manual update
 
-GitHub → Actions → **Update Graphify Graph** → Run workflow. The CI creates a PR `graphify/update-graph-report → dev-msf` with the updated report.
+GitHub → Actions → **Update Graphify Graph** → Run workflow. The CI creates a PR `graphify/update-graph-report` → `dev-msf` with the updated report.
 
 ### How Claude uses the graph
 


### PR DESCRIPTION
## Problème

Le workflow échouait avec `error: unknown command '.'` parce que `graphify .` n'est pas une commande valide dans graphifyy 0.5.7. Seul `graphify update .` existe pour générer le graphe.

## Changements

- `.github/workflows/update-graphify.yml` : retire l'input `semantic` et le branchement conditionnel — toujours `graphify update .`
- `CLAUDE.md` : retire la documentation sur le "semantic pass" qui n'existe pas dans cette version

## Test plan

- [ ] Merger cette PR
- [ ] Actions → **Update Graphify Graph** → Run workflow → vérifier qu'une PR `graphify/update-graph-report → dev-msf` est créée avec succès

https://claude.ai/code/session_015dEDZHpYezVNV4GSjg2yuZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015dEDZHpYezVNV4GSjg2yuZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Always run an AST-only graph update; removed the optional semantic pass and the requirement to provide semantic API credentials.
  * Pinned the graph tool to a specific version for more predictable behavior.

* **Documentation**
  * Updated CI guidance to automate PR-based graph report updates and describe how to use the report for code exploration.
  * Added a pre-tool hook to surface the graph report before running repository search commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->